### PR TITLE
Mass Moving command and Namespaces fix

### DIFF
--- a/TestBot/Modules/AudioModule.cs
+++ b/TestBot/Modules/AudioModule.cs
@@ -1,9 +1,8 @@
-﻿using Discord;
-using Discord.Commands;
-using System.Threading.Tasks;
+﻿using Discord.Commands;
+
 //using TestBot.Services;
 
-namespace TestBot.Modules
+namespace RavenBot.Modules
 {
     public class AudioModule : ModuleBase<ICommandContext>
     {

--- a/TestBot/Modules/DiscordMessage.cs
+++ b/TestBot/Modules/DiscordMessage.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
-namespace TestBot.Modules
+namespace RavenBot.Modules
 {
     public static class DiscordMessage
     {

--- a/TestBot/Modules/DiscordTable.cs
+++ b/TestBot/Modules/DiscordTable.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace TestBot.Modules
+namespace RavenBot.Modules
 {
     public class DiscordTable
     {

--- a/TestBot/Modules/ResponseModule.cs
+++ b/TestBot/Modules/ResponseModule.cs
@@ -1,11 +1,10 @@
-﻿using Discord.Commands;
-using Discord.Net;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using System.Net;
-using System.IO;
-using System.Collections.Generic;
+using Discord.Commands;
+using Discord.WebSocket;
 
-namespace TestBot.Modules
+namespace RavenBot.Modules
 {
     public class ResponseModule : ModuleBase<SocketCommandContext>
     {

--- a/TestBot/Modules/ResponseModule.cs
+++ b/TestBot/Modules/ResponseModule.cs
@@ -105,5 +105,31 @@ namespace RavenBot.Modules
                 }
             }
         }
+
+
+        [Command("mm")]
+        [Summary("Moves all users in current voice channel to given voice channel id.")]
+        [RequireUserPermission(Discord.GuildPermission.MoveMembers)]
+        public async Task MassMoveVoiceUsers(ulong channel)
+        {
+            SocketVoiceChannel newChannel = Context.Guild.GetVoiceChannel(channel);
+            if (newChannel == null)
+            {
+                await ReplyAsync("This channel does not exist here!");
+                return;
+            }
+
+            SocketVoiceChannel currentChannel = Context.Guild.VoiceChannels.FirstOrDefault(voice => voice.GetUser(Context.User.Id) == Context.User);
+            if (currentChannel == null)
+            {
+                await ReplyAsync("Make sure you are in a voice channel first!");
+                return;
+            }
+
+            foreach (var vUser in currentChannel.Users)
+            {
+                await vUser.ModifyAsync(properties => { properties.Channel = newChannel; });
+            }
+        }
     }
 }

--- a/TestBot/Modules/RunescapeHS.cs
+++ b/TestBot/Modules/RunescapeHS.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Net;
 using System.Collections.Generic;
+using System.Net;
 using Newtonsoft.Json;
 
-
-namespace TestBot.Modules
+namespace RavenBot.Modules
 {
     //https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=arrow
     public class SkillData

--- a/TestBot/MyBot.cs
+++ b/TestBot/MyBot.cs
@@ -1,18 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Discord;
-using Discord.Commands;
-using Discord.WebSocket;
-using Microsoft.Extensions.DependencyInjection;
-using TestBot.Services;
-
-using System.Diagnostics;
-using System.Reflection;
-
-namespace TestBot
+﻿namespace RavenBot
 {
     /*
     public class MyBot

--- a/TestBot/Program.cs
+++ b/TestBot/Program.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
-using TestBot.Services;
+using RavenBot.Services;
 
-namespace TestBot
+namespace RavenBot
 {
     class Program
     {

--- a/TestBot/Services/AudioService.cs
+++ b/TestBot/Services/AudioService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Audio;
 
-namespace TestBot.Services
+namespace RavenBot.Services
 {
     public class AudioService
     {

--- a/TestBot/Services/CommandHandler.cs
+++ b/TestBot/Services/CommandHandler.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using Discord;
+using System.Threading.Tasks;
 using Discord.Commands;
 using Discord.WebSocket;
-using System.Threading.Tasks;
 
-namespace TestBot.Services
+namespace RavenBot.Services
 {
     public class CommandHandler
     {
@@ -13,7 +12,7 @@ namespace TestBot.Services
         private readonly IServiceProvider _provider;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:TestBot.Services.CommandHandler"/> class.
+        /// Initializes a new instance of the <see cref="T:RavenBot.Services.CommandHandler"/> class.
         /// </summary>
         /// <param name="client">Client.</param>
         /// <param name="commands">Commands.</param>

--- a/TestBot/Services/LoggingService.cs
+++ b/TestBot/Services/LoggingService.cs
@@ -1,12 +1,11 @@
-﻿using Discord;
-using Discord.Commands;
-using Discord.WebSocket;
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
 
-
-namespace TestBot.Services
+namespace RavenBot.Services
 {
     public class LoggingService
     {

--- a/TestBot/Services/StartupService.cs
+++ b/TestBot/Services/StartupService.cs
@@ -1,13 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-using System.Diagnostics;
-using System.Reflection;
-using System.Threading.Tasks;
 
-namespace TestBot.Services
+namespace RavenBot.Services
 {
     public class StartupService
     {


### PR DESCRIPTION
Adds the ability to use !mm <voicechannelid> to move all users in current voice channel.

Permissions:
Must have MoveMembers enabled